### PR TITLE
Revert "Update beautifulsoup4 to 4.8.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ six==1.12.0
 wrapt==1.11.2
 
 pathos==0.2.5
-beautifulsoup4==4.8.0
+beautifulsoup4==4.6.0
 coverage
 mock
 nose


### PR DESCRIPTION
Reverts kenneyhe/BingRewards#107
fix missing get_text()
======================================================================
ERROR: test_bingparser (__main__.TestLong)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/configtest.py", line 1188, in test_bingparser
    self._bp(bdp.Reward())
  File "test/configtest.py", line 1205, in _bp
    self.assertIsNotNone(bdp.parseDashboardPage(DASHPG, bingCommon.ACCOUNT_URL), "should see rewards")
  File "/home/circleci/project/pkg/bingDashboardParser.py", line 77, in parseDashboardPage
    appendVariableReward(allRewards, bing_url, i, links)
  File "/home/circleci/project/pkg/bingDashboardParser.py", line 123, in appendVariableReward
    if foundText(rewardDescription, 'of'):
  File "/home/circleci/project/pkg/bingDashboardParser.py", line 179, in foundText
    return description.get_text().find(pattern) != -1
AttributeError: 'NoneType' object has no attribute 'get_text'

----------------------------------------------------------------------
Ran 41 tests in 14.759s
